### PR TITLE
Add main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "@toddmotto",
   "license": "MIT",
   "homepage": "https://github.com/toddmotto/lunar",
+  "main": "dist/lunar.js",
   "devDependencies": {
     "gulp": "~3.7.0",
     "gulp-uglify": "~0.3.0",


### PR DESCRIPTION
Adds a `main` property to package.json. Specifically for my use-case this helps when installing via [jspm];(http://jspm.io/) without it you need to provide an override config. However, my understanding is this helps with browserify &co. too so is worth adding in a general sense.